### PR TITLE
reto error ortografico Update logistic-regression.es.ipynb

### DIFF
--- a/06-ml_algos/logistic-regression.es.ipynb
+++ b/06-ml_algos/logistic-regression.es.ipynb
@@ -347,7 +347,7 @@
     "La interpretación de una matriz de confusión es la siguiente:\n",
     "\n",
     "- **Verdaderos positivos** (*TP, True positive*): Se corresponde con el número `142` y son los casos en los que el modelo predijo positivo (no supervivencia) y la clase real también es positiva.\n",
-    "- **Verdaderos negativos** (*TN, False negative*): Se corresponde con el número `80` y son los casos en los que el modelo predijo negativo (supervivencia) y la clase real también es negativa.\n",
+    "- **Verdaderos negativos** (*TN, True negative*): Se corresponde con el número `80` y son los casos en los que el modelo predijo negativo (supervivencia) y la clase real también es negativa.\n",
     "- **Falsos positivos** (*FP, False positive*): Se corresponde con el número `23` y son los casos en los que el modelo predijo positivo y la clase real es negativa.\n",
     "- **Falsos negativos** (*FN, False negative*): Se corresponde con el número `17` y son los casos en los que el modelo predijo negativo y la clase real es positiva.\n",
     "\n",


### PR DESCRIPTION
reto error ortográfico. Junto a "verdadero negativo" decía "False negative". Lo cambié a "True negative".