### PR TITLE
correccion ortografica "exploratory-data-analysis.es.ipynb"

### DIFF
--- a/05-data/exploratory-data-analysis.es.ipynb
+++ b/05-data/exploratory-data-analysis.es.ipynb
@@ -851,7 +851,7 @@
     "\n",
     "- **Survived**: El número de personas que no sobrevivieron superan en más de 300 a los que sí lo hicieron.\n",
     "- **Sex**: En el Titanic había casi el doble de hombres que de mujeres.\n",
-    "- **Pclass**: La suma de los pasajeros que viajaban en primera y segunda clase era casi idéntica a las que viajaban en tercera.\n",
+    "- **Pclass**: La suma de los pasajeros que viajaban en primera y segunda clase era casi idéntica a los que viajaban en tercera.\n",
     "- **Embarked**: La mayoría de los pasajeros del Titanic embarcaron en la estación de Southampton (`S`).\n",
     "- **SibSp**: Más de 800 pasajeros viajaron solos. Los restantes, con su pareja o alguien más de su familia.\n",
     "- **Parch**: Casi todos los pasajeros viajaron sin padres o hijos. Una pequeña parte sí lo hizo.\n",


### PR DESCRIPTION
Se realiza cambio en la frase " las que viajaban en tercera" por  "los que viajaban en tercera" debido a un error gramatical en el artículo de genero.

![image](https://github.com/user-attachments/assets/b99f8ceb-ad7a-44de-a44a-c8c12e289655)
