### PR TITLE
inconsistencia complemento de un suceso.

### DIFF
--- a/02-stats/probability.es.md
+++ b/02-stats/probability.es.md
@@ -29,7 +29,7 @@ Es el suceso que tiene lugar si ocurren ambos sucesos a la vez. Se denota por $A
 ![intersection](https://github.com/4GeeksAcademy/machine-learning-content/blob/master/assets/intersection.png?raw=true)
 
 #### Complemento de un suceso
-
+#Inconsistencia al emplear "E" como espacio muestral ("S"), ya que al comienzo de la explicación utilizan "E" para referirse a un evento.
 Es el suceso que tiene lugar si no ocurre el suceso dado. Se denota por $A'$. Por ejemplo, si $A$ es el suceso de obtener un número par al lanzar un dado, entonces $A'$ es el suceso de obtener un número impar.
 
 ![complement](https://github.com/4GeeksAcademy/machine-learning-content/blob/master/assets/complement.png?raw=true)


### PR DESCRIPTION
Inconsistencia al explicar el complemento de un suceso utilizando la letra "E" para explicar un espacio muestral, cuando al principio se da a entender que espacio muestral representa a "S" y evento a "E".