### PR TITLE
Update linear-algebra.es.ipynb

### DIFF
--- a/02-stats/linear-algebra.es.ipynb
+++ b/02-stats/linear-algebra.es.ipynb
@@ -126,7 +126,7 @@
             "id": "fe0d8d03",
             "metadata": {},
             "source": [
-                "**Tensores**: Los tensores son una matriz de números o funciones que se transmutan con ciertas reglas cuando cambian las coordenadas. Normalmente, el trabajo con tensores es más avanzado y requiere de librerías más orientadas al Machine Learning y a los modelos como `TensorFlow` o `PyTorch`.\n",
+                "**Tensores**: Los tensores es un objeto que generaliza conceptos como escalares, vectores y matrices, y que permite describir relaciones lineales o multilineales en espacios vectoriales. Normalmente, el trabajo con tensores es más avanzado y requiere de librerías más orientadas al Machine Learning y a los modelos como `TensorFlow` o `PyTorch`.\n",
                 "\n",
                 "El ***Machine Learning*** es el punto de contacto para Ciencias Informáticas y Estadística.\n",
                 "\n",


### PR DESCRIPTION
Realmente mi cambio no es necesario, y entiendo que la formalidad no es necesaria en un curso que pretende ser practico, pero no creo que llamar a un tensor simplemente una matriz sea lo más adecuado.