### PR TITLE
Bugfix: predictions based on X_test vs. y_test 

### DIFF
--- a/06-ml_algos/regularized-linear-models.md
+++ b/06-ml_algos/regularized-linear-models.md
@@ -46,7 +46,7 @@ lasso_model = Lasso(alpha = 0.1, max_iter = 300)
 
 lasso_model.fit(X_train, y_train)
 
-y_pred = lasso_model.predict(y_test)
+y_pred = lasso_model.predict(X_test)
 ```
 
 #### Ridge
@@ -61,5 +61,5 @@ ridge_model = Ridge(alpha = 0.1, max_iter = 300)
 
 ridge_model.fit(X_train, y_train)
 
-y_pred = ridge_model.predict(y_test)
+y_pred = ridge_model.predict(X_test)
 ```


### PR DESCRIPTION
...in regularized-linear-models.md

Corrected a typo in the example code given in this markdown file, because y_test is neither the data you'd want to run that line with, nor is it the correct shape (series vs. 2D) to be able to run a prediction on.