### PR TITLE
correction on model prediction calculations-algorithms.md

### DIFF
--- a/06-ml_algos/boosting-algorithms.md
+++ b/06-ml_algos/boosting-algorithms.md
@@ -60,7 +60,7 @@ model = GradientBoostingRegressor(n_estimators = 5, random_state = 42)
 
 model.fit(X_train, y_train)
 
-y_pred = model.predict(y_test)
+y_pred = model.predict(X_test)
 ```
 
 ### Model hyperparameterization


### PR DESCRIPTION
In the original code the y_test series was passed to the model to make predictions. Apart from being conceptually wrong (we are giving the data to predict to the model as input for predictions) this also would raise an error because the model expects data with the same number of columns as X_train.